### PR TITLE
adds tests for posts/new and authors/edit

### DIFF
--- a/spec/views/authors/edit.html.erb_spec.rb
+++ b/spec/views/authors/edit.html.erb_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe 'authors/edit', type: :feature do
+ 
+  let(:person) do
+    Author.create!(
+      email: 'Valid email',
+      name: 'Valid name',
+      phone_number: '5550350001'
+    )
+  end
+
+  before(:each) { visit edit_author_path(person) }
+
+  describe 'a blank form' do
+    it 'does not render an error list' do
+      expect(page).not_to have_selector('#error_explanation')
+    end
+
+    it 'does not render error fields' do
+      expect(page).not_to have_selector('.field_with_errors')
+    end
+  end
+
+  context 'invalid submissions' do
+    let(:invalid_attributes) do
+      { email: 'bro@sbahj.info', phone_number: '555035995' }
+  end
+
+    before(:each) do
+      Author.create(
+        email: invalid_attributes[:email],
+        name: 'Valid',
+        phone_number: '5550350001'
+      )
+
+      visit new_author_path
+      fill_in 'Email', with: invalid_attributes[:email]
+      fill_in 'Phone Number', with: invalid_attributes[:phone_number]
+      click_button 'Create'
+    end
+
+    it 'renders an error list' do
+      expect(all('#error_explanation li').size).to eq(3)
+    end
+
+    it 'prefills fields' do
+      expect(find('input[name=name]').value).to be_empty
+      expect(find('input[name=email]').value).to eq(invalid_attributes[:email])
+      expect(find('input[name=phone_number]').value).to eq(invalid_attributes[:phone_number])
+    end
+
+    it 'has error class on bad fields' do
+      expect(page).to have_css('.field_with_errors input[name=name]')
+      expect(page).to have_css('.field_with_errors input[name=email]')
+      expect(page).to have_css('.field_with_errors input[name=phone_number]')
+    end
+  end
+end

--- a/spec/views/posts/new.html.erb_spec.rb
+++ b/spec/views/posts/new.html.erb_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe "posts/new", type: :feature do
+  before(:each) { visit new_post_path }
+
+  describe "a blank form" do
+    it "does not render an error list" do
+      expect(page).not_to have_selector("#error_explanation")
+    end
+
+    it "does not render error fields" do
+      expect(page).not_to have_selector(".field_with_errors")
+    end
+  end
+
+  context "invalid submissions" do
+    let(:invalid_attributes) do
+      { title: nil, category: "Speculative Fiction", content: "too short" }
+    end
+
+    before(:each) do
+      Post.create(
+        title: invalid_attributes[:title],
+        category: "Fiction",
+        content: "Lorem ipsum dolar sit amet, consectetur adipiscing elit."
+      )
+
+      visit new_post_path
+      fill_in "Category", with: invalid_attributes[:category]
+      fill_in "Content", with: invalid_attributes[:content]
+      click_button "Create"
+    end
+
+    it "renders an error list" do
+      expect(all("#error_explanation li").size).to eq(3)
+    end
+
+    it "prefills fields" do
+      expect(find("input[name=title]").value).to be_empty
+      expect(find("input[name=category]").value).to eq(invalid_attributes[:category])
+      expect(find("input[name=content]").value).to eq(invalid_attributes[:content])
+    end
+
+    it "has error class on bad fields" do
+      expect(page).to have_css(".field_with_errors input[name=title]")
+      expect(page).to have_css(".field_with_errors input[name=category]")
+      expect(page).to have_css(".field_with_errors input[name=content]")
+    end
+  end
+end


### PR DESCRIPTION
Solves #16 
Thanks for flagging this, @sopharsogood! The intention of this lab _was_ to create 4 forms, but the tests did not reflect that. I just added some tests to reflect the other two form_for's (posts/new and authors/edit).

Thanks for contributing to the Flatiron School curriculum!

